### PR TITLE
added attachment support

### DIFF
--- a/testrail_mcp/mcp_server.py
+++ b/testrail_mcp/mcp_server.py
@@ -497,6 +497,17 @@ class TestRailMCPServer(FastMCP):
             """
             return self.client.delete_run(run_id)
         
+        # Tests tools
+        @self.tool("get_tests", description="Get all tests for a test run")
+        def get_tests(run_id: int) -> List[Dict]:
+            """
+            Get all tests for a test run.
+
+            Args:
+                run_id: The ID of the test run
+            """
+            return self.client.get_tests(run_id)
+
         # Results tools
         @self.tool("get_results", description="Get all test results for a test")
         def get_results(test_id: int) -> List[Dict]:

--- a/testrail_mcp/mcp_server.py
+++ b/testrail_mcp/mcp_server.py
@@ -352,6 +352,33 @@ class TestRailMCPServer(FastMCP):
 
             return self.client.move_section(section_id, data)
 
+        # Attachment tools
+        @self.tool("get_attachments_for_case", description="Get all attachments for a test case")
+        def get_attachments_for_case(
+            case_id: int,
+            limit: Optional[int] = None,
+            offset: Optional[int] = None
+        ) -> Dict:
+            """
+            Get all attachments for a test case.
+
+            Args:
+                case_id: The ID of the test case
+                limit: Number of attachments to return (default 250, requires TestRail 6.7+)
+                offset: Starting position for pagination (requires TestRail 6.7+)
+            """
+            return self.client.get_attachments_for_case(case_id, limit, offset)
+
+        @self.tool("get_attachment", description="Download an attachment by ID. Returns base64-encoded content and content type.")
+        def get_attachment(attachment_id: str) -> Dict:
+            """
+            Download an attachment by ID.
+
+            Args:
+                attachment_id: The ID of the attachment (string to support both integer and UUID formats)
+            """
+            return self.client.get_attachment(attachment_id)
+
         # Run tools
         @self.tool("get_run", description="Get a test run by ID")
         def get_run(run_id: int) -> Dict:

--- a/testrail_mcp/testrail_client.py
+++ b/testrail_mcp/testrail_client.py
@@ -170,6 +170,11 @@ class TestRailClient:
         """Delete a test run."""
         return self._send_request('POST', f'delete_run/{run_id}')
     
+    # Tests API
+    def get_tests(self, run_id: int) -> List[Dict]:
+        """Get all tests for a run."""
+        return self._send_request('GET', f'get_tests/{run_id}')
+
     # Results API
     def get_results(self, test_id: int) -> List[Dict]:
         """Get all results for a test."""

--- a/testrail_mcp/testrail_client.py
+++ b/testrail_mcp/testrail_client.py
@@ -74,6 +74,32 @@ class TestRailClient:
             
         return response.json() if response.content else {}
 
+    def _send_request_raw(self, method: str, uri: str) -> requests.Response:
+        """
+        Send a request and return the raw response (for binary downloads).
+
+        Args:
+            method: HTTP method (GET)
+            uri: API endpoint URI
+
+        Returns:
+            Raw requests.Response object
+
+        Raises:
+            Exception: If the request fails
+        """
+        url = self.base_url + uri
+        response = self.session.get(url)
+
+        if response.status_code >= 300:
+            try:
+                error = response.json()
+            except:
+                error = response.text
+            raise Exception(f"TestRail API returned HTTP {response.status_code}: {error}")
+
+        return response
+
     # Cases API
     def get_case(self, case_id: int) -> Dict:
         """Get a test case by ID."""
@@ -214,3 +240,24 @@ class TestRailClient:
     def move_section(self, section_id:int, data: Dict) -> Dict:
         """Move a section to a different parent or position"""
         return self._send_request('POST', f'move_section/{section_id}', data)
+
+    # Attachments API
+    def get_attachments_for_case(self, case_id: int, limit: Optional[int] = None, offset: Optional[int] = None) -> Dict:
+        """Get all attachments for a test case."""
+        uri = f'get_attachments_for_case/{case_id}'
+        params = []
+        if limit is not None:
+            params.append(f'limit={limit}')
+        if offset is not None:
+            params.append(f'offset={offset}')
+        if params:
+            uri += '&' + '&'.join(params)
+        return self._send_request('GET', uri)
+
+    def get_attachment(self, attachment_id: str) -> Dict:
+        """Download an attachment by ID. Returns base64-encoded content."""
+        response = self._send_request_raw('GET', f'get_attachment/{attachment_id}')
+        return {
+            'data': base64.b64encode(response.content).decode('ascii'),
+            'content_type': response.headers.get('Content-Type', 'application/octet-stream'),
+        }


### PR DESCRIPTION
The current mcp server doesn't support getting the attachment list for a test case and downloading the attachment for a given ID.

This merge has support for both of the above functionalities by exposing `get_attachments_for_case` and `get_attachment` tools.