### PR TITLE
Add delete safety controls and project allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The TestRail MCP server requires specific environment variables to authenticate 
    TESTRAIL_USERNAME=your-email@example.com
    TESTRAIL_API_KEY=your-api-key
    TESTRAIL_MCP_ALLOW_DELETES=false
+   TESTRAIL_ALLOWED_PROJECT_IDS=
    ```
 
    **Important Notes:**
@@ -66,6 +67,7 @@ The TestRail MCP server requires specific environment variables to authenticate 
    - `TESTRAIL_API_KEY` is your TestRail API key (not your password)
      - To generate an API key, log in to TestRail, go to "My Settings" > "API Keys" and create a new key
    - `TESTRAIL_MCP_ALLOW_DELETES` defaults to `false`. When false, destructive delete tools are not registered with the MCP server.
+   - `TESTRAIL_ALLOWED_PROJECT_IDS` is optional. When set to a comma-separated list such as `12,34`, mutation and delete tools are rejected unless the target entity belongs to one of those projects.
    - `preview_delete_section` is always available to return TestRail's soft-delete impact preview for a section.
    - When `TESTRAIL_MCP_ALLOW_DELETES=true`, `delete_section` still runs the soft-delete preview unless `confirm` exactly matches `DELETE SECTION <section_id>`.
 
@@ -108,7 +110,8 @@ In Claude Desktop, add a new server with the following configuration:
         "TESTRAIL_URL": "https://your-instance.testrail.io",
         "TESTRAIL_USERNAME": "your-email@example.com",
         "TESTRAIL_API_KEY": "your-api-key",
-        "TESTRAIL_MCP_ALLOW_DELETES": "false"
+        "TESTRAIL_MCP_ALLOW_DELETES": "false",
+        "TESTRAIL_ALLOWED_PROJECT_IDS": ""
       }
     }
   }
@@ -130,7 +133,8 @@ In Cursor, add a new custom tool with the following configuration:
     "TESTRAIL_URL": "https://your-instance.testrail.io",
     "TESTRAIL_USERNAME": "your-email@example.com",
     "TESTRAIL_API_KEY": "your-api-key",
-    "TESTRAIL_MCP_ALLOW_DELETES": "false"
+    "TESTRAIL_MCP_ALLOW_DELETES": "false",
+    "TESTRAIL_ALLOWED_PROJECT_IDS": ""
   }
 }
 ```
@@ -150,7 +154,8 @@ In Windsurf, add a new tool with the following configuration:
     "TESTRAIL_URL": "https://your-instance.testrail.io",
     "TESTRAIL_USERNAME": "your-email@example.com",
     "TESTRAIL_API_KEY": "your-api-key",
-    "TESTRAIL_MCP_ALLOW_DELETES": "false"
+    "TESTRAIL_MCP_ALLOW_DELETES": "false",
+    "TESTRAIL_ALLOWED_PROJECT_IDS": ""
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The TestRail MCP server requires specific environment variables to authenticate 
    TESTRAIL_URL=https://your-instance.testrail.io
    TESTRAIL_USERNAME=your-email@example.com
    TESTRAIL_API_KEY=your-api-key
+   TESTRAIL_MCP_ALLOW_DELETES=false
    ```
 
    **Important Notes:**
@@ -64,6 +65,9 @@ The TestRail MCP server requires specific environment variables to authenticate 
    - `TESTRAIL_USERNAME` is your TestRail email address used for login
    - `TESTRAIL_API_KEY` is your TestRail API key (not your password)
      - To generate an API key, log in to TestRail, go to "My Settings" > "API Keys" and create a new key
+   - `TESTRAIL_MCP_ALLOW_DELETES` defaults to `false`. When false, destructive delete tools are not registered with the MCP server.
+   - `preview_delete_section` is always available to return TestRail's soft-delete impact preview for a section.
+   - When `TESTRAIL_MCP_ALLOW_DELETES=true`, `delete_section` still runs the soft-delete preview unless `confirm` exactly matches `DELETE SECTION <section_id>`.
 
 2. Verify that the configuration is loaded correctly:
    ```bash
@@ -103,7 +107,8 @@ In Claude Desktop, add a new server with the following configuration:
       "env": {
         "TESTRAIL_URL": "https://your-instance.testrail.io",
         "TESTRAIL_USERNAME": "your-email@example.com",
-        "TESTRAIL_API_KEY": "your-api-key"
+        "TESTRAIL_API_KEY": "your-api-key",
+        "TESTRAIL_MCP_ALLOW_DELETES": "false"
       }
     }
   }
@@ -124,7 +129,8 @@ In Cursor, add a new custom tool with the following configuration:
   "env": {
     "TESTRAIL_URL": "https://your-instance.testrail.io",
     "TESTRAIL_USERNAME": "your-email@example.com",
-    "TESTRAIL_API_KEY": "your-api-key"
+    "TESTRAIL_API_KEY": "your-api-key",
+    "TESTRAIL_MCP_ALLOW_DELETES": "false"
   }
 }
 ```
@@ -143,7 +149,8 @@ In Windsurf, add a new tool with the following configuration:
   "env": {
     "TESTRAIL_URL": "https://your-instance.testrail.io",
     "TESTRAIL_USERNAME": "your-email@example.com",
-    "TESTRAIL_API_KEY": "your-api-key"
+    "TESTRAIL_API_KEY": "your-api-key",
+    "TESTRAIL_MCP_ALLOW_DELETES": "false"
   }
 }
 ```

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -23,6 +23,10 @@ startCommand:
         type: boolean
         description: Register destructive delete tools.
         default: false
+      allowedProjectIds:
+        type: string
+        description: Optional comma-separated project IDs allowed for mutation and delete tools.
+        default: ""
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -33,7 +37,8 @@ startCommand:
         TESTRAIL_URL: config.testRailUrl,
         TESTRAIL_USERNAME: config.testRailUsername,
         TESTRAIL_API_KEY: config.testRailApiKey,
-        TESTRAIL_MCP_ALLOW_DELETES: config.allowDeletes ? 'true' : 'false'
+        TESTRAIL_MCP_ALLOW_DELETES: config.allowDeletes ? 'true' : 'false',
+        TESTRAIL_ALLOWED_PROJECT_IDS: config.allowedProjectIds || ''
       }
     })
   exampleConfig:
@@ -41,3 +46,4 @@ startCommand:
     testRailUsername: user@example.com
     testRailApiKey: abcdef123456
     allowDeletes: false
+    allowedProjectIds: ""

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -19,6 +19,10 @@ startCommand:
       testRailApiKey:
         type: string
         description: Your TestRail API key.
+      allowDeletes:
+        type: boolean
+        description: Register destructive delete tools.
+        default: false
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -28,10 +32,12 @@ startCommand:
       env: {
         TESTRAIL_URL: config.testRailUrl,
         TESTRAIL_USERNAME: config.testRailUsername,
-        TESTRAIL_API_KEY: config.testRailApiKey
+        TESTRAIL_API_KEY: config.testRailApiKey,
+        TESTRAIL_MCP_ALLOW_DELETES: config.allowDeletes ? 'true' : 'false'
       }
     })
   exampleConfig:
     testRailUrl: https://example.testrail.io
     testRailUsername: user@example.com
     testRailApiKey: abcdef123456
+    allowDeletes: false

--- a/testrail_mcp/config.py
+++ b/testrail_mcp/config.py
@@ -13,6 +13,18 @@ TESTRAIL_MCP_ALLOW_DELETES = os.getenv(
     'TESTRAIL_MCP_ALLOW_DELETES',
     'false'
 ).strip().lower() in {'1', 'true', 'yes', 'on'}
+_allowed_project_ids = os.getenv('TESTRAIL_ALLOWED_PROJECT_IDS', '').strip()
+try:
+    TESTRAIL_ALLOWED_PROJECT_IDS = {
+        int(project_id.strip())
+        for project_id in _allowed_project_ids.split(',')
+        if project_id.strip()
+    }
+except ValueError as exc:
+    raise ValueError(
+        "TESTRAIL_ALLOWED_PROJECT_IDS must be a comma-separated list of "
+        "integer project IDs."
+    ) from exc
 
 # Validate configuration
 if not all([TESTRAIL_URL, TESTRAIL_USERNAME, TESTRAIL_API_KEY]):

--- a/testrail_mcp/config.py
+++ b/testrail_mcp/config.py
@@ -9,6 +9,10 @@ load_dotenv()
 TESTRAIL_URL = os.getenv('TESTRAIL_URL')
 TESTRAIL_USERNAME = os.getenv('TESTRAIL_USERNAME')
 TESTRAIL_API_KEY = os.getenv('TESTRAIL_API_KEY')
+TESTRAIL_MCP_ALLOW_DELETES = os.getenv(
+    'TESTRAIL_MCP_ALLOW_DELETES',
+    'false'
+).strip().lower() in {'1', 'true', 'yes', 'on'}
 
 # Validate configuration
 if not all([TESTRAIL_URL, TESTRAIL_USERNAME, TESTRAIL_API_KEY]):

--- a/testrail_mcp/mcp_server.py
+++ b/testrail_mcp/mcp_server.py
@@ -8,6 +8,7 @@ from testrail_mcp.config import (
     TESTRAIL_USERNAME,
     TESTRAIL_API_KEY,
     TESTRAIL_MCP_ALLOW_DELETES,
+    TESTRAIL_ALLOWED_PROJECT_IDS,
 )
 
 
@@ -20,6 +21,154 @@ class TestRailMCPServer(FastMCP):
         self.client = TestRailClient(TESTRAIL_URL, TESTRAIL_USERNAME, TESTRAIL_API_KEY)
         self._register_tools()
         self._register_resources()
+
+    def _ensure_project_allowed(self, project_id: int, operation: str) -> None:
+        """Reject writes outside TESTRAIL_ALLOWED_PROJECT_IDS when configured."""
+        if not TESTRAIL_ALLOWED_PROJECT_IDS:
+            return
+
+        try:
+            project_id = int(project_id)
+        except (TypeError, ValueError) as exc:
+            raise PermissionError(
+                f"Cannot determine project for {operation}; refusing because "
+                "TESTRAIL_ALLOWED_PROJECT_IDS is set."
+            ) from exc
+
+        if project_id not in TESTRAIL_ALLOWED_PROJECT_IDS:
+            allowed_ids = ", ".join(
+                str(allowed_id) for allowed_id in sorted(TESTRAIL_ALLOWED_PROJECT_IDS)
+            )
+            raise PermissionError(
+                f"{operation} is not allowed for project {project_id}. "
+                f"Allowed projects: {allowed_ids}."
+            )
+
+    def _ensure_case_allowed(self, case_id: int, operation: str) -> None:
+        if TESTRAIL_ALLOWED_PROJECT_IDS:
+            self._ensure_project_allowed(
+                self._project_id_for_case(case_id, operation),
+                operation
+            )
+
+    def _ensure_section_allowed(self, section_id: int, operation: str) -> None:
+        if TESTRAIL_ALLOWED_PROJECT_IDS:
+            self._ensure_project_allowed(
+                self._project_id_for_section(section_id, operation),
+                operation
+            )
+
+    def _ensure_run_allowed(self, run_id: int, operation: str) -> None:
+        if TESTRAIL_ALLOWED_PROJECT_IDS:
+            self._ensure_project_allowed(
+                self._project_id_for_run(run_id, operation),
+                operation
+            )
+
+    def _ensure_test_allowed(self, test_id: int, operation: str) -> None:
+        if TESTRAIL_ALLOWED_PROJECT_IDS:
+            self._ensure_project_allowed(
+                self._project_id_for_test(test_id, operation),
+                operation
+            )
+
+    def _ensure_dataset_allowed(self, dataset_id: int, operation: str) -> None:
+        if TESTRAIL_ALLOWED_PROJECT_IDS:
+            self._ensure_project_allowed(
+                self._project_id_for_dataset(dataset_id, operation),
+                operation
+            )
+
+    def _reject_project_creation_when_allowlisted(self, operation: str) -> None:
+        if TESTRAIL_ALLOWED_PROJECT_IDS:
+            raise PermissionError(
+                f"{operation} is not allowed when TESTRAIL_ALLOWED_PROJECT_IDS "
+                "is set because the new project cannot already be allowlisted."
+            )
+
+    def _project_id_from_payload(
+        self,
+        payload: Dict,
+        entity_name: str,
+        entity_id: int,
+        operation: str
+    ) -> int:
+        project_id = payload.get('project_id')
+        if project_id is None:
+            raise PermissionError(
+                f"Cannot determine project for {operation} on "
+                f"{entity_name} {entity_id}; refusing because "
+                "TESTRAIL_ALLOWED_PROJECT_IDS is set."
+            )
+        try:
+            return int(project_id)
+        except (TypeError, ValueError) as exc:
+            raise PermissionError(
+                f"Invalid project ID for {operation} on {entity_name} "
+                f"{entity_id}; refusing because TESTRAIL_ALLOWED_PROJECT_IDS "
+                "is set."
+            ) from exc
+
+    def _project_id_for_suite(self, suite_id: int, operation: str) -> int:
+        suite = self.client.get_suite(suite_id)
+        return self._project_id_from_payload(suite, "suite", suite_id, operation)
+
+    def _project_id_for_section(self, section_id: int, operation: str) -> int:
+        section = self.client.get_section(section_id)
+        project_id = section.get('project_id')
+        if project_id is not None:
+            return self._project_id_from_payload(section, "section", section_id, operation)
+
+        suite_id = section.get('suite_id')
+        if suite_id is None:
+            raise PermissionError(
+                f"Cannot determine project for {operation} on section "
+                f"{section_id}; refusing because TESTRAIL_ALLOWED_PROJECT_IDS "
+                "is set."
+            )
+        return self._project_id_for_suite(suite_id, operation)
+
+    def _project_id_for_case(self, case_id: int, operation: str) -> int:
+        test_case = self.client.get_case(case_id)
+        project_id = test_case.get('project_id')
+        if project_id is not None:
+            return self._project_id_from_payload(test_case, "case", case_id, operation)
+
+        suite_id = test_case.get('suite_id')
+        if suite_id is not None:
+            return self._project_id_for_suite(suite_id, operation)
+
+        section_id = test_case.get('section_id')
+        if section_id is not None:
+            return self._project_id_for_section(section_id, operation)
+
+        raise PermissionError(
+            f"Cannot determine project for {operation} on case {case_id}; "
+            "refusing because TESTRAIL_ALLOWED_PROJECT_IDS is set."
+        )
+
+    def _project_id_for_run(self, run_id: int, operation: str) -> int:
+        run = self.client.get_run(run_id)
+        return self._project_id_from_payload(run, "run", run_id, operation)
+
+    def _project_id_for_test(self, test_id: int, operation: str) -> int:
+        test = self.client.get_test(test_id)
+        project_id = test.get('project_id')
+        if project_id is not None:
+            return self._project_id_from_payload(test, "test", test_id, operation)
+
+        run_id = test.get('run_id')
+        if run_id is not None:
+            return self._project_id_for_run(run_id, operation)
+
+        raise PermissionError(
+            f"Cannot determine project for {operation} on test {test_id}; "
+            "refusing because TESTRAIL_ALLOWED_PROJECT_IDS is set."
+        )
+
+    def _project_id_for_dataset(self, dataset_id: int, operation: str) -> int:
+        dataset = self.client.get_dataset(dataset_id)
+        return self._project_id_from_payload(dataset, "dataset", dataset_id, operation)
     
     def _register_tools(self):
         """Register all TestRail tools with the MCP server."""
@@ -50,6 +199,7 @@ class TestRailMCPServer(FastMCP):
                 show_announcement: Whether to show the announcement (optional)
                 suite_mode: The suite mode: 1 for single suite mode, 2 for single suite + baselines, 3 for multiple suites (optional)
             """
+            self._reject_project_creation_when_allowlisted("add_project")
             data = {'name': name}
             if announcement is not None:
                 data['announcement'] = announcement
@@ -77,6 +227,7 @@ class TestRailMCPServer(FastMCP):
                 show_announcement: Whether to show the announcement (optional)
                 is_completed: Whether the project is completed (optional)
             """
+            self._ensure_project_allowed(project_id, "update_project")
             data = {}
             if name is not None:
                 data['name'] = name
@@ -97,6 +248,7 @@ class TestRailMCPServer(FastMCP):
                 Args:
                     project_id: The ID of the project
                 """
+                self._ensure_project_allowed(project_id, "delete_project")
                 return self.client.delete_project(project_id)
         
         # Case tools
@@ -159,6 +311,7 @@ class TestRailMCPServer(FastMCP):
                     - additional_info: The text contents of the "Additional Info" field
                     - refs: Reference information for the "References" field
             """
+            self._ensure_section_allowed(section_id, "add_case")
             data = {'title': title}
             if type_id is not None:
                 data['type_id'] = type_id
@@ -217,6 +370,7 @@ class TestRailMCPServer(FastMCP):
                     - additional_info: The text contents of the "Additional Info" field
                     - refs: Reference information for the "References" field
             """
+            self._ensure_case_allowed(case_id, "update_case")
             data = {}
             if title is not None:
                 data['title'] = title
@@ -249,6 +403,7 @@ class TestRailMCPServer(FastMCP):
                 Args:
                     case_id: The ID of the test case
                 """
+                self._ensure_case_allowed(case_id, "delete_case")
                 return self.client.delete_case(case_id)
         # Section tools
         @self.tool("get_section", description="Retrieves details of a specific section by ID")
@@ -293,6 +448,7 @@ class TestRailMCPServer(FastMCP):
                 parent_id: The ID of the parent
 
             """
+            self._ensure_project_allowed(project_id, "add_section")
             data = {}
             data["name"] = name
             data["description"] = description
@@ -316,6 +472,7 @@ class TestRailMCPServer(FastMCP):
                 name: Name of the section
                 description: Description of the section
             """
+            self._ensure_section_allowed(section_id, "update_section")
             data = {}
             if name is not None:
                 data["name"] = name
@@ -332,6 +489,7 @@ class TestRailMCPServer(FastMCP):
             Args:
                 section_id: The ID of the section
             """
+            self._ensure_section_allowed(section_id, "preview_delete_section")
             return self.client.delete_section(section_id, soft=True)
 
         if TESTRAIL_MCP_ALLOW_DELETES:
@@ -346,6 +504,7 @@ class TestRailMCPServer(FastMCP):
                     section_id: The ID of the section
                     confirm: Must exactly match DELETE SECTION <section_id> to actually delete. Otherwise this returns a soft-delete preview.
                 """
+                self._ensure_section_allowed(section_id, "delete_section")
                 if confirm != f"DELETE SECTION {section_id}":
                     return self.client.delete_section(section_id, soft=True)
 
@@ -364,6 +523,11 @@ class TestRailMCPServer(FastMCP):
                 parent_id: ID of the new parent
                 after_id: ID of the section to be moved after
             """
+            self._ensure_section_allowed(section_id, "move_section")
+            if parent_id is not None:
+                self._ensure_section_allowed(parent_id, "move_section")
+            if after_id is not None:
+                self._ensure_section_allowed(after_id, "move_section")
             data = {}
             if parent_id is not None:
                 data["parent_id"] = parent_id
@@ -417,6 +581,7 @@ class TestRailMCPServer(FastMCP):
                 include_all: True for including all test cases of the test suite and false for a custom case selection (default: true) (optional)
                 case_ids: An array of case IDs for the custom case selection (optional)
             """
+            self._ensure_project_allowed(project_id, "add_run")
             data = {
                 'suite_id': suite_id,
                 'name': name
@@ -455,6 +620,7 @@ class TestRailMCPServer(FastMCP):
                 include_all: True for including all test cases of the test suite and false for a custom case selection (default: true) (optional)
                 case_ids: An array of case IDs for the custom case selection (optional)
             """
+            self._ensure_run_allowed(run_id, "update_run")
             data = {}
             if name is not None:
                 data['name'] = name
@@ -478,6 +644,7 @@ class TestRailMCPServer(FastMCP):
             Args:
                 run_id: The ID of the test run
             """
+            self._ensure_run_allowed(run_id, "close_run")
             return self.client.close_run(run_id)
         
         if TESTRAIL_MCP_ALLOW_DELETES:
@@ -489,6 +656,7 @@ class TestRailMCPServer(FastMCP):
                 Args:
                     run_id: The ID of the test run
                 """
+                self._ensure_run_allowed(run_id, "delete_run")
                 return self.client.delete_run(run_id)
         
         # Results tools
@@ -524,6 +692,7 @@ class TestRailMCPServer(FastMCP):
                 defects: A comma-separated list of defects to link to the test result (optional)
                 assignedto_id: The ID of a user the test should be assigned to (optional)
             """
+            self._ensure_test_allowed(test_id, "add_result")
             data = {
                 'status_id': status_id
             }
@@ -574,6 +743,7 @@ class TestRailMCPServer(FastMCP):
                 name: The name of the dataset
                 description: The description of the dataset (optional)
             """
+            self._ensure_project_allowed(project_id, "add_dataset")
             data = {
                 'name': name
             }
@@ -595,6 +765,7 @@ class TestRailMCPServer(FastMCP):
                 name: The name of the dataset (optional)
                 description: The description of the dataset (optional)
             """
+            self._ensure_dataset_allowed(dataset_id, "update_dataset")
             data = {}
             if name is not None:
                 data['name'] = name
@@ -611,6 +782,7 @@ class TestRailMCPServer(FastMCP):
                 Args:
                     dataset_id: The ID of the dataset
                 """
+                self._ensure_dataset_allowed(dataset_id, "delete_dataset")
                 return self.client.delete_dataset(dataset_id)
     
     def _register_resources(self):

--- a/testrail_mcp/mcp_server.py
+++ b/testrail_mcp/mcp_server.py
@@ -3,7 +3,12 @@ from typing import Dict, List, Any, Optional, Union
 from fastmcp import FastMCP
 
 from testrail_mcp.testrail_client import TestRailClient
-from testrail_mcp.config import TESTRAIL_URL, TESTRAIL_USERNAME, TESTRAIL_API_KEY
+from testrail_mcp.config import (
+    TESTRAIL_URL,
+    TESTRAIL_USERNAME,
+    TESTRAIL_API_KEY,
+    TESTRAIL_MCP_ALLOW_DELETES,
+)
 
 
 class TestRailMCPServer(FastMCP):
@@ -83,15 +88,16 @@ class TestRailMCPServer(FastMCP):
                 data['is_completed'] = is_completed
             return self.client.update_project(project_id, data)
         
-        @self.tool("delete_project", description="Delete a project")
-        def delete_project(project_id: int) -> Dict:
-            """
-            Delete a project.
-            
-            Args:
-                project_id: The ID of the project
-            """
-            return self.client.delete_project(project_id)
+        if TESTRAIL_MCP_ALLOW_DELETES:
+            @self.tool("delete_project", description="Delete a project")
+            def delete_project(project_id: int) -> Dict:
+                """
+                Delete a project.
+
+                Args:
+                    project_id: The ID of the project
+                """
+                return self.client.delete_project(project_id)
         
         # Case tools
         @self.tool("get_case", description="Get a test case by ID")
@@ -234,15 +240,16 @@ class TestRailMCPServer(FastMCP):
                 data['custom_expected'] = custom_expected
             return self.client.update_case(case_id, data)
         
-        @self.tool("delete_case", description="Delete a test case")
-        def delete_case(case_id: int) -> Dict:
-            """
-            Delete a test case.
-            
-            Args:
-                case_id: The ID of the test case
-            """
-            return self.client.delete_case(case_id)
+        if TESTRAIL_MCP_ALLOW_DELETES:
+            @self.tool("delete_case", description="Delete a test case")
+            def delete_case(case_id: int) -> Dict:
+                """
+                Delete a test case.
+
+                Args:
+                    case_id: The ID of the test case
+                """
+                return self.client.delete_case(case_id)
         # Section tools
         @self.tool("get_section", description="Retrieves details of a specific section by ID")
         def get_section(section_id: int) -> Dict:
@@ -317,19 +324,32 @@ class TestRailMCPServer(FastMCP):
 
             return self.client.update_section(section_id, data)
 
-        @self.tool("delete_section", description="Deletes a section")
-        def delete_section(
-            section_id : int,
-            soft: bool) -> Dict:
+        @self.tool("preview_delete_section", description="Preview deleting a section")
+        def preview_delete_section(section_id: int) -> Dict:
             """
-            Deletes an existing section
+            Preview the impact of deleting an existing section.
             
             Args:
                 section_id: The ID of the section
-                soft: Omitting the soft parameter, or submitting soft=0 will delete the section and its test cases If soft=1, this will return data on the number of affected tests, cases, etc.
             """
+            return self.client.delete_section(section_id, soft=True)
 
-            return self.client.delete_section(section_id, soft)
+        if TESTRAIL_MCP_ALLOW_DELETES:
+            @self.tool("delete_section", description="Preview or delete a section")
+            def delete_section(
+                section_id : int,
+                confirm: Optional[str] = None) -> Dict:
+                """
+                Preview or delete an existing section.
+
+                Args:
+                    section_id: The ID of the section
+                    confirm: Must exactly match DELETE SECTION <section_id> to actually delete. Otherwise this returns a soft-delete preview.
+                """
+                if confirm != f"DELETE SECTION {section_id}":
+                    return self.client.delete_section(section_id, soft=True)
+
+                return self.client.delete_section(section_id, soft=False)
 
         @self.tool("move_section", description="Moves a section to a new position in the test hierarchy")
         def move_section(
@@ -460,15 +480,16 @@ class TestRailMCPServer(FastMCP):
             """
             return self.client.close_run(run_id)
         
-        @self.tool("delete_run", description="Delete a test run")
-        def delete_run(run_id: int) -> Dict:
-            """
-            Delete a test run.
-            
-            Args:
-                run_id: The ID of the test run
-            """
-            return self.client.delete_run(run_id)
+        if TESTRAIL_MCP_ALLOW_DELETES:
+            @self.tool("delete_run", description="Delete a test run")
+            def delete_run(run_id: int) -> Dict:
+                """
+                Delete a test run.
+
+                Args:
+                    run_id: The ID of the test run
+                """
+                return self.client.delete_run(run_id)
         
         # Results tools
         @self.tool("get_results", description="Get all test results for a test")
@@ -581,15 +602,16 @@ class TestRailMCPServer(FastMCP):
                 data['description'] = description
             return self.client.update_dataset(dataset_id, data)
         
-        @self.tool("delete_dataset", description="Delete a dataset")
-        def delete_dataset(dataset_id: int) -> Dict:
-            """
-            Delete a dataset.
-            
-            Args:
-                dataset_id: The ID of the dataset
-            """
-            return self.client.delete_dataset(dataset_id)
+        if TESTRAIL_MCP_ALLOW_DELETES:
+            @self.tool("delete_dataset", description="Delete a dataset")
+            def delete_dataset(dataset_id: int) -> Dict:
+                """
+                Delete a dataset.
+
+                Args:
+                    dataset_id: The ID of the dataset
+                """
+                return self.client.delete_dataset(dataset_id)
     
     def _register_resources(self):
         """Register all TestRail resources with the MCP server."""

--- a/testrail_mcp/testrail_client.py
+++ b/testrail_mcp/testrail_client.py
@@ -143,6 +143,16 @@ class TestRailClient:
     def delete_run(self, run_id: int) -> Dict:
         """Delete a test run."""
         return self._send_request('POST', f'delete_run/{run_id}')
+
+    # Suites API
+    def get_suite(self, suite_id: int) -> Dict:
+        """Get a test suite by ID."""
+        return self._send_request('GET', f'get_suite/{suite_id}')
+
+    # Tests API
+    def get_test(self, test_id: int) -> Dict:
+        """Get a test by ID."""
+        return self._send_request('GET', f'get_test/{test_id}')
     
     # Results API
     def get_results(self, test_id: int) -> List[Dict]:


### PR DESCRIPTION
## Summary
- hide destructive delete tools unless `TESTRAIL_MCP_ALLOW_DELETES` is enabled
- add `preview_delete_section` as the always-available soft-delete preview path
- require `confirm="DELETE SECTION <section_id>"` before `delete_section` performs a hard delete
- add optional `TESTRAIL_ALLOWED_PROJECT_IDS=12,34` project allowlisting for mutation/delete tools
- resolve indirect mutation targets before writes, including sections, cases, runs, tests/results, and datasets
- document the new env flags in README and Smithery config

## Behavior
- when `TESTRAIL_ALLOWED_PROJECT_IDS` is empty, existing write behavior is preserved
- when it is set, mutation/delete tools reject targets outside the configured projects
- `add_project` is rejected while allowlisting is configured because a new project cannot already be allowlisted

## Validation
- `python -m compileall testrail_mcp`
- `git diff --check`
- runtime tool-list checks with `TESTRAIL_MCP_ALLOW_DELETES=false` and `true`
- section delete call check verifies preview uses `soft=True` and exact confirmation uses `soft=False`
- mocked allowlist checks for direct project writes, section/case writes, test result writes, dataset writes, and section delete previews
- mocked empty-allowlist check to confirm existing write behavior is preserved
- invalid allowlist startup check for non-integer IDs